### PR TITLE
Update Postgres from 17.4 to 17.6

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -12,7 +12,7 @@ services:
 
   ############## DATABASE AND VISUALIZER ##############
   postgres:
-    image: postgres:17.4
+    image: postgres:17.6
     ports:
       - "5432:5432"
     volumes:

--- a/test/integration/containerSupport.js
+++ b/test/integration/containerSupport.js
@@ -4,7 +4,7 @@ const { LocalstackContainer } = require("@testcontainers/localstack");
 const path = require("path");
 
 async function createAndBootstrapPostgresContainer() {
-  const postgresContainer = await new PostgreSqlContainer("postgres:17.4")
+  const postgresContainer = await new PostgreSqlContainer("postgres:17.6")
     .withCopyFilesToContainer([
       {
         source: path.join(__dirname, "../../dev/db/1-create-schema.sql"),


### PR DESCRIPTION
## Summary
- Updated Compose file to use postgres:17.6
- Updated integration tests to use postgres:17.6
- Verified all integration tests pass with the new version

## Test plan
- [x] Updated compose.yaml to use postgres:17.6
- [x] Updated test/integration/containerSupport.js to use postgres:17.6
- [x] Ran integration tests successfully (4/4 tests passed)

Fixes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)