### PR TITLE
Update PostgreSQL from 17.4 to 17.6

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -12,7 +12,7 @@ services:
 
   ############## DATABASE AND VISUALIZER ##############
   postgres:
-    image: postgres:17.4
+    image: postgres:17.6
     ports:
       - "5432:5432"
     volumes:

--- a/test/integration/containerSupport.js
+++ b/test/integration/containerSupport.js
@@ -4,7 +4,7 @@ const { LocalstackContainer } = require("@testcontainers/localstack");
 const path = require("path");
 
 async function createAndBootstrapPostgresContainer() {
-  const postgresContainer = await new PostgreSqlContainer("postgres:17.4")
+  const postgresContainer = await new PostgreSqlContainer("postgres:17.6")
     .withCopyFilesToContainer([
       {
         source: path.join(__dirname, "../../dev/db/1-create-schema.sql"),


### PR DESCRIPTION
## Summary

Updates PostgreSQL version from 17.4 to 17.6 to align with the infra team's production database upgrade.

## Changes

- ✅ Updated `compose.yaml` to use `postgres:17.6`
- ✅ Updated integration tests in `test/integration/containerSupport.js` to use `postgres:17.6`
- ✅ Ran integration tests to validate compatibility

## Testing

Integration tests were executed successfully with the new PostgreSQL 17.6 image. All containers started properly and tests passed.

Closes #1

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)